### PR TITLE
libnss_tcb: Use readdir(3) with glibc >= 2.24.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,13 @@
 	* pam_tcb/Makefile: Likewise.
 	* progs/Makefile: Likewise.
 
+	libnss_tcb: Use readdir(3) with glibc >= 2.24.
+	* libs/nss.c (_nss_tcb_getspnam_r): glibc, since version 2.24,
+	has deprecated readdir_r(3).  It is recommended that applications
+	use readdir(3) instead of readdir_r(3).  Also use thread local
+	storage for the underlying directory stream in this case.
+	* LICENSE: Update copyright for this contribution.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2021-09-25  Björn Esser  <besser82 at fedoraporject.org>
+2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if
 	libcrypt really implements it.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2001, 2002 Rafal Wojtczuk <nergal at owl.openwall.com>
 Copyright (c) 2001 - 2003 Solar Designer <solar at owl.openwall.com>
 Copyright (c) 2001, 2003 - 2006, 2009, 2010, 2012, 2018, 2020 Dmitry V. Levin <ldv at owl.openwall.com>
-Copyright (c) 2021 Björn Esser <besser82 at fedoraporject.org>
+Copyright (c) 2021 Björn Esser <besser82 at fedoraproject.org>
 
 Additionally, some or all of the following copyright notices may apply
 to portions of pam_tcb and tcb_chkpwd:


### PR DESCRIPTION
It is recommended that applications use readdir(3) instead of readdir_r(3).  Furthermore, since version 2.24, glibc deprecates
readdir_r(3).

Also use thread local storage for the underlying directory stream in this case.