### PR TITLE
Small improvements to Makefiles.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@
 	libnss_tcb: Apply proper soname during linking.
 	* libs/Makefile: Apply proper soname to libnss_tcb.so.2.
 
+	libnss_tcb: Drop unneeded LIBNSL from linked libraries.
+	* libs/Makefile: Stop linking libnss_tcb.so.2 against LIBNSL.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,9 @@
 	defined to 0, which means libxcrypt does not provide a best-choice
 	default prefix.
 
+	libnss_tcb: Apply proper soname during linking.
+	* libs/Makefile: Apply proper soname to libnss_tcb.so.2.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,14 @@
 	libnss_tcb: Drop unneeded LIBNSL from linked libraries.
 	* libs/Makefile: Stop linking libnss_tcb.so.2 against LIBNSL.
 
+	make: Allow install and mkdir programs to be user configurable.
+	Also pass an explicit dirmode to MKDIR.
+	* Make.defs: Allow for configurable install and mkdir programs.
+	* libs/Makefile: Likewise.
+	* misc/Makefile: Likewise.
+	* pam_tcb/Makefile: Likewise.
+	* progs/Makefile: Likewise.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/Make.defs
+++ b/Make.defs
@@ -1,4 +1,7 @@
 CC = gcc
+INSTALL = install -p
+MKDIR = mkdir
+
 DBGFLAG = #-ggdb
 ifndef CFLAGS
 CFLAGS = -O2

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -23,8 +23,8 @@ $(LIBTCB_LONG): libtcb.o $(LIB_MAP)
 	ln -sf $(LIBTCB) libtcb.so
 
 $(LIBNSS): nss.o $(NSS_MAP) $(LIBTCB_LONG)
-	$(CC) $(LDFLAGS) -shared -o $@ -Wl,--version-script=$(NSS_MAP) \
-		$< $(LIBNSL) -ltcb
+	$(CC) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBNSS) \
+		-Wl,--version-script=$(NSS_MAP) $< $(LIBNSL) -ltcb
 
 .c.o:
 	$(CC) $(CFLAGS) -fPIC -c $< -o $@

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -32,13 +32,13 @@ $(LIBNSS): nss.o $(NSS_MAP) $(LIBTCB_LONG)
 install-non-root: install
 
 install:
-	mkdir -p $(DESTDIR)$(SLIBDIR)
-	mkdir -p $(DESTDIR)$(LIBDIR)
-	install -m $(SHLIBMODE) $(LIBTCB_LONG) $(DESTDIR)$(SLIBDIR)/
+	$(MKDIR) -p -m 755 $(DESTDIR)$(SLIBDIR)
+	$(MKDIR) -p -m 755 $(DESTDIR)$(LIBDIR)
+	$(INSTALL) -m $(SHLIBMODE) $(LIBTCB_LONG) $(DESTDIR)$(SLIBDIR)/
 	ln -sf $(LIBTCB_LONG) $(DESTDIR)$(SLIBDIR)/$(LIBTCB)
 	ln -sf ../..$(SLIBDIR)/$(LIBTCB) $(DESTDIR)$(LIBDIR)/libtcb.so
-	install -m $(SHLIBMODE) $(LIBNSS) $(DESTDIR)$(SLIBDIR)/
-	install -m 644 $(LIBTCB_A) $(DESTDIR)$(LIBDIR)/
+	$(INSTALL) -m $(SHLIBMODE) $(LIBNSS) $(DESTDIR)$(SLIBDIR)/
+	$(INSTALL) -m 644 $(LIBTCB_A) $(DESTDIR)$(LIBDIR)/
 
 clean:
 	rm -f *.o *~ $(LIBTCB)* libtcb.so $(LIBNSS) *.a

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -24,7 +24,7 @@ $(LIBTCB_LONG): libtcb.o $(LIB_MAP)
 
 $(LIBNSS): nss.o $(NSS_MAP) $(LIBTCB_LONG)
 	$(CC) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBNSS) \
-		-Wl,--version-script=$(NSS_MAP) $< $(LIBNSL) -ltcb
+		-Wl,--version-script=$(NSS_MAP) $< -ltcb
 
 .c.o:
 	$(CC) $(CFLAGS) -fPIC -c $< -o $@

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -5,8 +5,8 @@ all clean:
 install-non-root: install
 
 install:
-	mkdir -p $(DESTDIR)$(MANDIR)/man5
-	mkdir -p $(DESTDIR)/usr/include
+	$(MKDIR) -p -m 755 $(DESTDIR)$(MANDIR)/man5
+	$(MKDIR) -p -m 755 $(DESTDIR)/usr/include
 
-	install -m 644 tcb.5 $(DESTDIR)$(MANDIR)/man5/
-	install -m 644 ../include/tcb.h $(DESTDIR)/usr/include/
+	$(INSTALL) -m 644 tcb.5 $(DESTDIR)$(MANDIR)/man5/
+	$(INSTALL) -m 644 ../include/tcb.h $(DESTDIR)/usr/include/

--- a/pam_tcb/Makefile
+++ b/pam_tcb/Makefile
@@ -25,10 +25,10 @@ support.o: support.c
 install-non-root: install
 
 install:
-	mkdir -p $(DESTDIR)$(SLIBDIR)/security
-	mkdir -p $(DESTDIR)$(MANDIR)/man8
-	install -m $(SHLIBMODE) $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/
-	install -p -m 644 pam_tcb.8 $(DESTDIR)$(MANDIR)/man8/
+	$(MKDIR) -p -m 755 $(DESTDIR)$(SLIBDIR)/security
+	$(MKDIR) -p -m 755 $(DESTDIR)$(MANDIR)/man8
+	$(INSTALL) -m $(SHLIBMODE) $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/
+	$(INSTALL) -m 644 pam_tcb.8 $(DESTDIR)$(MANDIR)/man8/
 
 install-pam_unix: install
 	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix.so
@@ -36,11 +36,11 @@ install-pam_unix: install
 	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_auth.so
 	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_passwd.so
 	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_session.so
-	install -p -m 644 pam_unix.8 $(DESTDIR)$(MANDIR)/man8/
+	$(INSTALL) -m 644 pam_unix.8 $(DESTDIR)$(MANDIR)/man8/
 
 install-pam_pwdb: install
 	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_pwdb.so
-	install -p -m 644 pam_pwdb.8 $(DESTDIR)$(MANDIR)/man8/
+	$(INSTALL) -m 644 pam_pwdb.8 $(DESTDIR)$(MANDIR)/man8/
 
 clean:
 	rm -f *.o *~ $(PAM_TCB)

--- a/progs/Makefile
+++ b/progs/Makefile
@@ -19,21 +19,21 @@ $(CHKPWD): $(CHKPWD).o
 	$(CC) $(CFLAGS) -c $< -o $@
 
 install-non-root: install-common
-	install -d -m 710 $(DESTDIR)$(LIBEXECDIR)/chkpwd
-	install -m 700 $(CHKPWD) $(DESTDIR)$(LIBEXECDIR)/chkpwd/
+	$(INSTALL) -d -m 710 $(DESTDIR)$(LIBEXECDIR)/chkpwd
+	$(INSTALL) -m 700 $(CHKPWD) $(DESTDIR)$(LIBEXECDIR)/chkpwd/
 
 install: install-common
-	install -d -o root -g chkpwd -m 710 $(DESTDIR)$(LIBEXECDIR)/chkpwd
-	install -m 2711 -o root -g shadow $(CHKPWD) \
+	$(INSTALL) -d -o root -g chkpwd -m 710 $(DESTDIR)$(LIBEXECDIR)/chkpwd
+	$(INSTALL) -m 2711 -o root -g shadow $(CHKPWD) \
 		$(DESTDIR)$(LIBEXECDIR)/chkpwd/
 
 install-common:
-	mkdir -p $(DESTDIR)$(SBINDIR)
-	mkdir -p $(DESTDIR)$(MANDIR)/man8
-	install -m 700 $(CONVERT) $(DESTDIR)$(SBINDIR)/
-	install -m 700 $(UNCONVERT) $(DESTDIR)$(SBINDIR)/
-	install -m 644 $(CONVERT).8 $(DESTDIR)$(MANDIR)/man8/
-	install -m 644 $(UNCONVERT).8 $(DESTDIR)$(MANDIR)/man8/
+	$(MKDIR) -p -m 755 $(DESTDIR)$(SBINDIR)
+	$(MKDIR) -p -m 755 $(DESTDIR)$(MANDIR)/man8
+	$(INSTALL) -m 700 $(CONVERT) $(DESTDIR)$(SBINDIR)/
+	$(INSTALL) -m 700 $(UNCONVERT) $(DESTDIR)$(SBINDIR)/
+	$(INSTALL) -m 644 $(CONVERT).8 $(DESTDIR)$(MANDIR)/man8/
+	$(INSTALL) -m 644 $(UNCONVERT).8 $(DESTDIR)$(MANDIR)/man8/
 
 clean:
 	rm -f $(CONVERT) $(UNCONVERT) $(CHKPWD) *.o *~


### PR DESCRIPTION
libnss_tcb: Apply proper soname during linking.
* libs/Makefile: Apply proper soname to libnss_tcb.so.2.

Rationale from the [GNU libc manual Section 29.4.1](https://www.gnu.org/software/libc/manual/html_node/Adding-another-Service-to-NSS.html#Adding-another-Service-to-NSS):

Developers of a new service will have to make sure that their module is created using the correct interface number.  This means the file itself must have the correct name and on ELF systems the soname (Shared Object Name) must also have this number.

***

libnss_tcb: Drop unneeded LIBNSL from linked libraries.
* libs/Makefile: Stop linking libnss_tcb.so.2 against LIBNSL.

The NIS+ support has been removed long time ago, so there is no need to link against LIBNSL anymore.

***

make: Allow install and mkdir programs to be user configurable.
* Make.defs: Allow for configurable install and mkdir programs.
* libs/Makefile: Likewise.
* misc/Makefile: Likewise.
* pam_tcb/Makefile: Likewise.
* progs/Makefile: Likewise.