### PR TITLE
pam_tcb: Request automatic prefix only if libcrypt really implements it.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2021-09-25  Björn Esser  <besser82 at fedoraporject.org>
+
+	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if
+	libcrypt really implements it.
+	In some specific, but unusual, build-time configurations of libxcrypt
+	the CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX feature-test macro is
+	defined to 0, which means libxcrypt does not provide a best-choice
+	default prefix.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Copyright (c) 2001, 2002 Rafal Wojtczuk <nergal at owl.openwall.com>
 Copyright (c) 2001 - 2003 Solar Designer <solar at owl.openwall.com>
 Copyright (c) 2001, 2003 - 2006, 2009, 2010, 2012, 2018, 2020 Dmitry V. Levin <ldv at owl.openwall.com>
+Copyright (c) 2021 Björn Esser <besser82 at fedoraporject.org>
 
 Additionally, some or all of the following copyright notices may apply
 to portions of pam_tcb and tcb_chkpwd:

--- a/pam_tcb/support.c
+++ b/pam_tcb/support.c
@@ -840,7 +840,8 @@ int _set_ctrl(pam_handle_t *pamh, int flags, int argc, const char **argv)
 			return 0;
 	param = get_optval("prefix=", the_cmdline_opts);
 	pam_unix_param.crypt_prefix = param;
-#ifndef CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX
+#if !defined(CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX) || \
+    !CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX
 	if (!pam_unix_param.crypt_prefix)
 		pam_unix_param.crypt_prefix = "$2b$";
 #endif


### PR DESCRIPTION
In libxcrypt, starting with version 4.0.0, supplying a null pointer as the `prefix` argument to the `crypt_gensalt_ra()` function will cause it to select the best available hash function.

Starting with version 4.1.0, libxcrypt provides the `CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX` macro to test the availability of this feature at build time.

However, in some specific, but unusual, build-time configurations of libxcrypt the `CRYPT_GENSALT_IMPLEMENTS_DEFAULT_PREFIX` feature-test macro is defined to `0`, which means libxcrypt does not provide a best-choice default prefix.