### PR TITLE
pam_tcb: Allow setting a custom PAM_SO_SUFFIX during build.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,12 @@
 	storage for the underlying directory stream in this case.
 	* LICENSE: Update copyright for this contribution.
 
+	pam_tcb: Allow setting a custom PAM_SO_SUFFIX during build.
+	At least FreeBSD and NetBSD are using OpenPAM, which needs
+	the ability to specify a PAM_SO_SUFFIX to externally built
+	modules.
+	* pam_tcb/Makefile: Honor PAM_SO_SUFFIX variable.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/pam_tcb/Makefile
+++ b/pam_tcb/Makefile
@@ -1,6 +1,7 @@
 include ../Make.defs
 
-PAM_TCB = pam_tcb.so
+PAM_SO_SUFFIX =
+PAM_TCB = pam_tcb.so$(PAM_SO_SUFFIX)
 PAM_MAP = pam_tcb.map
 
 LIBSRC = \
@@ -31,15 +32,15 @@ install:
 	$(INSTALL) -m 644 pam_tcb.8 $(DESTDIR)$(MANDIR)/man8/
 
 install-pam_unix: install
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix.so
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_acct.so
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_auth.so
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_passwd.so
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_session.so
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix.so$(PAM_SO_SUFFIX)
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_acct.so$(PAM_SO_SUFFIX)
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_auth.so$(PAM_SO_SUFFIX)
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_passwd.so$(PAM_SO_SUFFIX)
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_unix_session.so$(PAM_SO_SUFFIX)
 	$(INSTALL) -m 644 pam_unix.8 $(DESTDIR)$(MANDIR)/man8/
 
 install-pam_pwdb: install
-	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_pwdb.so
+	ln -s $(PAM_TCB) $(DESTDIR)$(SLIBDIR)/security/pam_pwdb.so$(PAM_SO_SUFFIX)
 	$(INSTALL) -m 644 pam_pwdb.8 $(DESTDIR)$(MANDIR)/man8/
 
 clean:


### PR DESCRIPTION
At least FreeBSD and NetBSD are using OpenPAM, which needs the ability to specify a `PAM_SO_SUFFIX` to externally built modules.