### PR TITLE
pam_tcb: Apply proper soname during linking if PAM_SO_SUFFIX is set.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /libs/libtcb.so
 /libs/libtcb.so.0
 /libs/libtcb.so.0.*
-/pam_tcb/pam_tcb.so
+/pam_tcb/pam_tcb.so*
 /progs/tcb_chkpwd
 /progs/tcb_convert
 /progs/tcb_unconvert

--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,9 @@
 	* pam_tcb/Makefile: Apply proper soname with PAM_SO_SUFFIX
 	not being empty. Adapt clean target also.
 
+	* .gitignore: Adapt ignore rule for pam_tcb.so with
+	PAM_SO_SUFFIX set.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,11 @@
 	modules.
 	* pam_tcb/Makefile: Honor PAM_SO_SUFFIX variable.
 
+	pam_tcb: Apply proper soname during linking if PAM_SO_SUFFIX
+	is set.
+	* pam_tcb/Makefile: Apply proper soname with PAM_SO_SUFFIX
+	not being empty. Adapt clean target also.
+
 2021-09-25  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Add github CI.

--- a/pam_tcb/Makefile
+++ b/pam_tcb/Makefile
@@ -4,6 +4,10 @@ PAM_SO_SUFFIX =
 PAM_TCB = pam_tcb.so$(PAM_SO_SUFFIX)
 PAM_MAP = pam_tcb.map
 
+ifneq ($(PAM_SO_SUFFIX),)
+PAM_TCB_SONAME = -Wl,-soname,$(PAM_TCB)
+endif
+
 LIBSRC = \
 	pam_unix_auth.c pam_unix_acct.c pam_unix_sess.c pam_unix_passwd.c \
 	support.c compat.c
@@ -13,8 +17,8 @@ LIBOBJ = $(LIBSRC:.c=.o)
 all: $(PAM_TCB)
 
 $(PAM_TCB): $(LIBOBJ) $(PAM_MAP)
-	$(CC) $(LDFLAGS) -shared -o $@ -Wl,--version-script=$(PAM_MAP) \
-		$(LIBOBJ) -lcrypt -lpam -ltcb
+	$(CC) $(LDFLAGS) -shared -o $@ $(PAM_TCB_SONAME) \
+		-Wl,--version-script=$(PAM_MAP) $(LIBOBJ) -lcrypt -lpam -ltcb
 
 .c.o:
 	$(CC) $(CFLAGS) -fPIC -c $< -o $@
@@ -44,4 +48,4 @@ install-pam_pwdb: install
 	$(INSTALL) -m 644 pam_pwdb.8 $(DESTDIR)$(MANDIR)/man8/
 
 clean:
-	rm -f *.o *~ $(PAM_TCB)
+	rm -f *.o *~ $(PAM_TCB)*


### PR DESCRIPTION
pam_tcb: Apply proper soname during linking if `PAM_SO_SUFFIX` is set.
* pam_tcb/Makefile: Apply proper soname with `PAM_SO_SUFFIX` not being empty. Adapt clean target also.

***

* .gitignore: Adapt ignore rule for pam_tcb.so with `PAM_SO_SUFFIX` set.

***

These are changes missing in #5.