### PR TITLE
misc: Add preset file for systemd-sysusers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /libs/libtcb.so
 /libs/libtcb.so.0
 /libs/libtcb.so.0.*
+/misc/tcb.sysusers
 /pam_tcb/pam_tcb.so*
 /progs/tcb_chkpwd
 /progs/tcb_convert

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,20 @@
 
 	* ci/run-build-and-tests.sh: Build with "-Werror" enabled on CI.
 
+	misc: Add preset file for systemd-sysusers.
+	Such preset files are used with distributions that rely
+	on systemd-sysusers to ensure all required system users
+	and system groups are present on system boot.
+	* Make.defs: Add preset for SYSUSERSDIR.
+	* Makefile: Add (optional) top-level "install-sysusers" and
+	"install-sysusers-auth" targets.
+	* misc/Makefile: Likewise, with also adding build and clean
+	targets.
+	"install-sysusers-auth" targets.
+	* misc/tcb.sysusers.in: New file.
+	* misc/tcb-auth.sysusers: New file.
+	* .gitignore: Add build output from "misc" directory.
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/Make.defs
+++ b/Make.defs
@@ -22,5 +22,6 @@ SLIBDIR = /lib
 LIBDIR = /usr/lib
 LIBEXECDIR = /usr/libexec
 MANDIR = /usr/man
+SYSUSERSDIR = /usr/lib/sysusers.d
 
 SHLIBMODE = 755

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ all install install-non-root clean:
 
 install-pam_unix install-pam_pwdb:
 	$(MAKE) -C pam_tcb $@
+
+install-sysusers install-sysusers-auth:
+	$(MAKE) -C misc $@

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -1,6 +1,9 @@
 include ../Make.defs
 
-all clean:
+all: tcb.sysusers
+
+tcb.sysusers: tcb.sysusers.in
+	sed -e "s!@LIBEXECDIR@!$(LIBEXECDIR)!g" < $< > $@
 
 install-non-root: install
 
@@ -10,3 +13,13 @@ install:
 
 	$(INSTALL) -m 644 tcb.5 $(DESTDIR)$(MANDIR)/man5/
 	$(INSTALL) -m 644 ../include/tcb.h $(DESTDIR)/usr/include/
+
+install-sysusers:
+	$(MKDIR) -p -m 755 $(DESTDIR)$(SYSUSERSDIR)
+	$(INSTALL) -m 644 tcb.sysusers $(DESTDIR)$(SYSUSERSDIR)/tcb.conf
+
+install-sysusers-auth: install-sysusers
+	$(INSTALL) -m 644 tcb-auth.sysusers $(DESTDIR)$(SYSUSERSDIR)/tcb-auth.conf
+
+clean:
+	rm -f tcb.sysusers

--- a/misc/tcb-auth.sysusers
+++ b/misc/tcb-auth.sysusers
@@ -1,0 +1,4 @@
+# Additional access group for the tcb password shadowing scheme
+# when "TCB_AUTH_GROUP yes" is in use.
+# The "root" user is guaranteed to be present on any system.
+g auth /etc/tcb/root

--- a/misc/tcb.sysusers.in
+++ b/misc/tcb.sysusers.in
@@ -1,0 +1,3 @@
+# Access groups for the tcb password shadowing scheme
+g chkpwd @LIBEXECDIR@/chkpwd
+g shadow /etc/tcb


### PR DESCRIPTION
Such a preset file is used with distributions that rely on `systemd-sysusers` to ensure all required system users and system groups are present on system boot.

The preset file can be installed by the optional `install-sysusers` target.

* Make.defs: Add preset for `SYSUSERSDIR`.
* Makefile: Add (optional) top-level `install-sysusers` and `install-sysusers-auth` targets.
* misc/Makefile: Likewise, with also adding build and clean targets.
* misc/tcb.sysusers.in: New file.
* misc/tcb-auth.sysusers: New file.
* .gitignore: Add build output from `misc` directory.