### PR TITLE
Fix several advanced compiler warnings.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@
 	* Make.defs: Add "-Wextra" to default CFLAGS.  Add an option to
 	enable "-Werror" also.
 
+	* ci/run-build-and-tests.sh: Build with "-Werror" enabled on CI.
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,9 @@
 	* pam_tcb/support.h (pam_tcb_getlogin): New function.
 	Small static inline wrapper around getlogin(3).
 
+	* Make.defs: Add "-Wextra" to default CFLAGS.  Add an option to
+	enable "-Werror" also.
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2021-09-30  Björn Esser  <besser82 at fedoraproject.org>
+
+	pam_tcb: Fix "-Wpedantic".
+	* pam_tcb/pam_unix_auth.c (pam_sm_authenticate): ISO C forbids
+	omitting the middle term of a '?:' expression.
+	* pam_tcb/pam_unix_sess.c (pam_sm_open_session): Likewise.
+	* pam_tcb/pam_unix_passwd.c (pam_sm_chauthtok): Likewise.
+	* pam_tcb/pam_unix_passwd.c (unix_prelim): Likewise.
+	* pam_tcb/support.c (_set_ctrl): Likewise.
+	* pam_tcb/support.h (pam_tcb_getlogin): New function.
+	Small static inline wrapper around getlogin(3).
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/Make.defs
+++ b/Make.defs
@@ -2,11 +2,18 @@ CC = gcc
 INSTALL = install -p
 MKDIR = mkdir
 
+# Flag to enable -Werror on build.
+WERROR =
+
 DBGFLAG = #-ggdb
 ifndef CFLAGS
 CFLAGS = -O2
 endif
-CFLAGS += $(DBGFLAG) -I../include -Wall
+CFLAGS += $(DBGFLAG) -I../include
+CFLAGS += -Wall -Wextra
+ifneq ($(WERROR),)
+CFLAGS += -Werror
+endif
 #CFLAGS += -DFAIL_RECORD
 LDFLAGS += $(DBGFLAG) -L../libs
 

--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -30,7 +30,7 @@ nproc="$(nproc)" || nproc=1
 j="-j$nproc"
 
 CFLAGS='-O2 -Wall -W -DENABLE_SETFSUGID -DENABLE_NLS -DNLS_PACKAGE=\"Linux-PAM\"' \
-	make -k $j CC="$CC"
+	make -k $j CC="$CC" WERROR=1
 
 if git status --porcelain |grep ^.; then
 	echo >&2 'git status reported uncleanness'

--- a/pam_tcb/pam_unix_auth.c
+++ b/pam_tcb/pam_unix_auth.c
@@ -128,7 +128,7 @@ out_save_retval:
 		pam_syslog(pamh, retval == PAM_SUCCESS ? LOG_INFO : LOG_NOTICE,
 		    "Authentication %s for %s from %s(uid=%u)",
 		    retval == PAM_SUCCESS ? "passed" : "failed", user,
-		    getlogin() ?: "", getuid());
+		    pam_tcb_getlogin(), getuid());
 	}
 
 	D(("done [%s]", pam_strerror(pamh, retval)));

--- a/pam_tcb/pam_unix_passwd.c
+++ b/pam_tcb/pam_unix_passwd.c
@@ -435,7 +435,7 @@ out:
 	    "Authentication %s for %s from %s(uid=%u)"
 	    ", for password management",
 	    retval == PAM_SUCCESS ? "passed" : "failed", user,
-	    getlogin() ?: "", getuid());
+	    pam_tcb_getlogin(), getuid());
 
 	return retval;
 }
@@ -576,7 +576,7 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 	if (retval == PAM_SUCCESS) {
 		pam_syslog(pamh, LOG_INFO,
 		    "Password for %s changed by %s(uid=%u)",
-		    user, getlogin() ?: "", getuid());
+		    user, pam_tcb_getlogin(), getuid());
 	}
 
 	D(("retval was %d", retval));

--- a/pam_tcb/pam_unix_sess.c
+++ b/pam_tcb/pam_unix_sess.c
@@ -42,7 +42,7 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags,
 	}
 
 	pam_syslog(pamh, LOG_INFO, "Session opened for %s by %s(uid=%u)",
-	    user, getlogin() ?: "", getuid());
+	    user, pam_tcb_getlogin(), getuid());
 
 	return PAM_SUCCESS;
 }

--- a/pam_tcb/support.c
+++ b/pam_tcb/support.c
@@ -576,7 +576,7 @@ static int do_record_failure(pam_handle_t *pamh, const char *user, int retval)
 			new->user = strdup(getpwnam(user) ?
 			    user : "UNKNOWN USER");
 			new->id = getuid();
-			new->name = strdup(getlogin() ?: "");
+			new->name = strdup(pam_tcb_getlogin());
 
 			/* any previous failures for this user? */
 			if (pam_get_data(pamh, data_name, &item)
@@ -847,7 +847,7 @@ int _set_ctrl(pam_handle_t *pamh, int flags, int argc, const char **argv)
 #endif
 
 	param = get_optval("helper=", the_cmdline_opts);
-	pam_unix_param.helper = param ?: CHKPWD_HELPER;
+	pam_unix_param.helper = param ? param : CHKPWD_HELPER;
 
 	param = get_optval("count=", the_cmdline_opts);
 	if (param) {

--- a/pam_tcb/support.h
+++ b/pam_tcb/support.h
@@ -178,4 +178,13 @@ extern int unix_getspnam(struct spwd **, const struct passwd *);
 extern char *crypt_wrapper(pam_handle_t *, const char *, const char *);
 extern char *do_crypt(pam_handle_t *, const char *);
 
+/* Helper function around getlogin() */
+static inline char *pam_tcb_getlogin(void)
+{
+	char *login = getlogin();
+	if (!login)
+		return "";
+	return login;
+}
+
 #endif


### PR DESCRIPTION
pam_tcb: Fix `-Wpedantic`.
* pam_tcb/pam_unix_auth.c (pam_sm_authenticate): ISO C forbids omitting the middle term of a `?:` expression.
* pam_tcb/pam_unix_sess.c (pam_sm_open_session): Likewise.
* pam_tcb/pam_unix_passwd.c (pam_sm_chauthtok): Likewise.
* pam_tcb/pam_unix_passwd.c (unix_prelim): Likewise.
* pam_tcb/support.c (_set_ctrl): Likewise.
* pam_tcb/support.h (pam_tcb_getlogin): New function.  Small static inline wrapper around getlogin(3).

***

* Make.defs: Make.defs: Add "-Wextra" to default CFLAGS.  Add an option to enable `-Werror` also.

***

* ci/run-build-and-tests.sh: Build with `-Werror` enabled on CI.