### PR TITLE
misc: Add pkgconfig file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /libs/libtcb.so
 /libs/libtcb.so.0
 /libs/libtcb.so.0.*
+/misc/tcb.pc
 /misc/tcb.sysusers
 /pam_tcb/pam_tcb.so*
 /progs/tcb_chkpwd

--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,8 @@
 	* tcb.spec: Add pkgconfig file.
 	* .gitignore: Add ignore rule for tcb.pc.
 
+	* Make.defs: Change MANDIR to "/usr/share/man".
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,21 @@
 	* misc/tcb-auth.sysusers: New file.
 	* .gitignore: Add build output from "misc" directory.
 
+	misc: Add pkgconfig file.
+	pkgconfig files provide a useful mechanism for storing various
+	information about libraries and packages on a given system.
+	Information stored by .pc files include compiler and linker flags
+	necessary to use a given library, as well as any other relevant
+	metadata.
+	* Make.defs: Add new presets for PREFIX, INCLUDEDIR, and
+	PKGCONFIGDIR.  Also adapt the existing presets slightly.
+	* misc/Makefile: Build and install the pkgconfig file.
+	Also use INCLUDEDIR instead of hardcoding its path, and
+	adapt the clean target.
+	* misc/tcb.pc.in: New file.
+	* tcb.spec: Add pkgconfig file.
+	* .gitignore: Add ignore rule for tcb.pc.
+
 2021-09-25  Björn Esser  <besser82 at fedoraproject.org>
 
 	* pam_tcb/support.c (_set_ctrl): Request automatic prefix only if

--- a/Make.defs
+++ b/Make.defs
@@ -17,11 +17,14 @@ endif
 #CFLAGS += -DFAIL_RECORD
 LDFLAGS += $(DBGFLAG) -L../libs
 
+PREFIX = /usr
 SBINDIR = /sbin
 SLIBDIR = /lib
-LIBDIR = /usr/lib
-LIBEXECDIR = /usr/libexec
-MANDIR = /usr/man
-SYSUSERSDIR = /usr/lib/sysusers.d
+INCLUDEDIR = $(PREFIX)/include
+LIBDIR = $(PREFIX)/lib
+LIBEXECDIR = $(PREFIX)/libexec
+MANDIR = $(PREFIX)/man
+PKGCONFIGDIR = $(LIBDIR)/pkgconfig
+SYSUSERSDIR = $(PREFIX)/lib/sysusers.d
 
 SHLIBMODE = 755

--- a/Make.defs
+++ b/Make.defs
@@ -23,7 +23,7 @@ SLIBDIR = /lib
 INCLUDEDIR = $(PREFIX)/include
 LIBDIR = $(PREFIX)/lib
 LIBEXECDIR = $(PREFIX)/libexec
-MANDIR = $(PREFIX)/man
+MANDIR = $(PREFIX)/share/man
 PKGCONFIGDIR = $(LIBDIR)/pkgconfig
 SYSUSERSDIR = $(PREFIX)/lib/sysusers.d
 

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -1,6 +1,13 @@
 include ../Make.defs
 
-all: tcb.sysusers
+VERSION != sed -e "/^Version: */!d;s///;q" < ../tcb.spec
+
+all: tcb.pc tcb.sysusers
+
+tcb.pc: tcb.pc.in
+	sed -e "s!@PREFIX@!$(PREFIX)!g" -e "s!@SLIBDIR@!$(SLIBDIR)!g" \
+		-e "s!@INCLUDEDIR@!$(INCLUDEDIR)!g" -e "s!@VERSION@!$(VERSION)!g" \
+		< $< > $@
 
 tcb.sysusers: tcb.sysusers.in
 	sed -e "s!@LIBEXECDIR@!$(LIBEXECDIR)!g" < $< > $@
@@ -9,10 +16,12 @@ install-non-root: install
 
 install:
 	$(MKDIR) -p -m 755 $(DESTDIR)$(MANDIR)/man5
-	$(MKDIR) -p -m 755 $(DESTDIR)/usr/include
+	$(MKDIR) -p -m 755 $(DESTDIR)$(INCLUDEDIR)
+	$(MKDIR) -p -m 755 $(DESTDIR)$(PKGCONFIGDIR)
 
 	$(INSTALL) -m 644 tcb.5 $(DESTDIR)$(MANDIR)/man5/
-	$(INSTALL) -m 644 ../include/tcb.h $(DESTDIR)/usr/include/
+	$(INSTALL) -m 644 ../include/tcb.h $(DESTDIR)$(INCLUDEDIR)
+	$(INSTALL) -m 644 tcb.pc $(DESTDIR)$(PKGCONFIGDIR)
 
 install-sysusers:
 	$(MKDIR) -p -m 755 $(DESTDIR)$(SYSUSERSDIR)
@@ -22,4 +31,4 @@ install-sysusers-auth: install-sysusers
 	$(INSTALL) -m 644 tcb-auth.sysusers $(DESTDIR)$(SYSUSERSDIR)/tcb-auth.conf
 
 clean:
-	rm -f tcb.sysusers
+	rm -f tcb.pc tcb.sysusers

--- a/misc/tcb.pc.in
+++ b/misc/tcb.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=@SLIBDIR@
+includedir=@INCLUDEDIR@
+
+Name: tcb
+Description: Library implementing the tcb password shadowing scheme
+Version: @VERSION@
+Libs: -L${libdir} -ltcb
+Cflags: -I${includedir}

--- a/tcb.spec
+++ b/tcb.spec
@@ -87,6 +87,7 @@ rmdir /sbin/chkpwd.d
 %_includedir/tcb.h
 %_libdir/libtcb.a
 %_libdir/libtcb.so
+%_libdir/pkgconfig/tcb.pc
 
 %changelog
 * Mon Jan 11 2021 Solar Designer <solar-at-owl.openwall.com> 1.2-owl1


### PR DESCRIPTION
misc: Add pkgconfig file.
pkgconfig files provide a useful mechanism for storing various information about libraries and packages on a given system.  Information stored by `.pc` files include compiler and linker flags necessary to use a given library, as well as any other relevant metadata.
* Make.defs: Add new presets for `PREFIX`, `INCLUDEDIR`, and `PKGCONFIGDIR`.  Also adapt the existing presets slightly.
* misc/Makefile: Build and install the pkgconfig file.  Also use `INCLUDEDIR` instead of hardcoding its path, and adapt the clean target.
* misc/tcb.pc.in: New file.
* tcb.spec: Add pkgconfig file.
* .gitignore: Add ignore rule for `tcb.pc`.