### PR TITLE
libtcb: Add versioning to exported symbols.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 2021-12-18  Björn Esser  <besser82 at fedoraproject.org>
 
+	libtcb: Add versioning to exported symbols.
+	This change is implemented for adding some interfaces to libtcb to
+	give it a more consumer friendly API and thus makes porting existing
+	applications to be TCB aware easier.
+	* libs/libtcb.map: Declare version for exported symbols.
+
 	* pam_tcb/Makefile: Move PAM_SO_SUFFIX to Make.defs.
 	* Make.defs: Likewise.
 

--- a/libs/libtcb.map
+++ b/libs/libtcb.map
@@ -1,6 +1,6 @@
 # $Owl$
 
-{
+TCB_0.9.8 {
   global:
     lckpwdf_tcb;
     ulckpwdf_tcb;


### PR DESCRIPTION
libtcb: Add versioning to exported symbols.

This change is implemented for adding some interfaces to libtcb to give it a more consumer friendly API and thus makes porting existing applications to be TCB aware easier.

* libs/libtcb.map: Declare version for exported symbols.