### PR TITLE
Make libnss_tcb thread-safe

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-01-21  Dmitry V. Levin  <ldv at owl.openwall.com>
+
+	Use setgroups syscall instead of the libc function.
+	* libs/libtcb.c (sys_setgroups): New function, a thin wrapper around
+	setgroups syscall.
+	(tcb_drop_priv_r, tcb_gain_priv_r): Use it instead of setgroups.
+
 2023-01-20  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Make -DENABLE_SETFSUGID the default and only implementation.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-01-20  Dmitry V. Levin  <ldv at owl.openwall.com>
+
+	Make -DENABLE_SETFSUGID the default and only implementation.
+	* libs/libtcb.c [!ENABLE_SETFSUGID]: Remove.
+	* tcb.spec: Remove -DENABLE_SETFSUGID.
+	* ci/run-build-and-tests.sh: Likewise.
+
 2021-09-30  Björn Esser  <besser82 at fedoraproject.org>
 
 	pam_tcb: Fix "-Wpedantic".

--- a/ci/run-build-and-tests.sh
+++ b/ci/run-build-and-tests.sh
@@ -29,7 +29,7 @@ echo 'END OF BUILD ENVIRONMENT INFORMATION'
 nproc="$(nproc)" || nproc=1
 j="-j$nproc"
 
-CFLAGS='-O2 -Wall -W -DENABLE_SETFSUGID -DENABLE_NLS -DNLS_PACKAGE=\"Linux-PAM\"' \
+CFLAGS='-O2 -Wall -W -DENABLE_NLS -DNLS_PACKAGE=\"Linux-PAM\"' \
 	make -k $j CC="$CC" WERROR=1
 
 if git status --porcelain |grep ^.; then

--- a/libs/libtcb.c
+++ b/libs/libtcb.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/fsuid.h>
 
 #include "tcb.h"
 #include "attribute.h"
@@ -140,8 +141,6 @@ int ulckpwdf_tcb(void)
 static gid_t glob_grplist[TCB_NGROUPS];
 static struct tcb_privs glob_privs = { glob_grplist, 0, -1, -1, 0 };
 
-#ifdef ENABLE_SETFSUGID
-#include <sys/fsuid.h>
 /*
  * Two setfsuid() in a row - stupid, but how the hell am I supposed to check
  * whether setfsuid() succeeded?
@@ -160,20 +159,6 @@ static int ch_gid(gid_t gid, gid_t *save)
 		*save = tmp;
 	return (gid_t) setfsgid(gid) == gid;
 }
-#else
-static int ch_uid(uid_t uid, uid_t *save)
-{
-	if (save)
-		*save = geteuid();
-	return setreuid(-1, uid) != -1;
-}
-static int ch_gid(gid_t gid, gid_t *save)
-{
-	if (save)
-		*save = getegid();
-	return setregid(-1, gid) != -1;
-}
-#endif
 
 #define PRIV_MAGIC			0x1004000a
 #define PRIV_MAGIC_NONROOT		0xdead000a

--- a/tcb.spec
+++ b/tcb.spec
@@ -38,7 +38,7 @@ building tcb-aware applications.
 %setup -q
 
 %build
-CFLAGS="%optflags -DENABLE_SETFSUGID" %__make
+CFLAGS="%optflags" %__make
 
 %install
 rm -rf %buildroot


### PR DESCRIPTION
Use setfsuid/setfsgid instead of setreuid/setregid unconditionally.
Also, use setgroups syscall instead of the libc function.
This makes tcb_drop_priv_r and tcb_gain_priv_r functions thread-safe.

Resolves: #15