### PR TITLE
github: add gcc-14 and clang-18/clang-17/clang-16 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-11
       TARGET: x86_64
@@ -53,7 +53,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc10-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-10
       TARGET: x86_64
@@ -67,7 +67,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc9-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc
       TARGET: x86_64
@@ -137,7 +137,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang12-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-12
       TARGET: x86_64
@@ -151,7 +151,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-11
       TARGET: x86_64
@@ -165,7 +165,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang10-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang
       TARGET: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ jobs:
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
+  gcc14-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-14
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:
@@ -84,6 +98,48 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CC: gcc-8
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang18-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-18
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang17-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-17
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang16-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-16
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-10-17  Dmitry V. Levin  <ldv at owl.openwall.com>
+
+	pam_tcb: Use _pam_delete in the compat implementation of pam_prompt.
+	* pam_tcb/compat.c (pam_prompt): Use _pam_delete instead of
+	_pam_overwrite followed by _pam_drop.
+
 2023-01-21  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	Use setgroups syscall instead of the libc function.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 2024-10-17  Dmitry V. Levin  <ldv at owl.openwall.com>
 
+	pam_tcb: Do not use deprecated _pam_overwrite macro.
+	* pam_tcb/support.h (pam_tcb_overwrite_string): New macro.
+	(_pam_delete): Replace _pam_overwrite with pam_tcb_overwrite_string.
+	* pam_tcb/pam_unix_passwd.c (pam_sm_chauthtok): Likewise.
+
 	pam_tcb: Use _pam_delete in the compat implementation of pam_prompt.
 	* pam_tcb/compat.c (pam_prompt): Use _pam_delete instead of
 	_pam_overwrite followed by _pam_drop.

--- a/pam_tcb/compat.c
+++ b/pam_tcb/compat.c
@@ -108,13 +108,9 @@ pam_prompt(pam_handle_t *pamh, int style, char **response, const char *fmt, ...)
 	if (response)
 		*response = pam_resp == NULL ? NULL : pam_resp->resp;
 	else if (pam_resp && pam_resp->resp)
-	{
-		_pam_overwrite(pam_resp->resp);
-		_pam_drop(pam_resp->resp);
-	}
-	_pam_overwrite(msgbuf);
+		_pam_delete(pam_resp->resp);
+	_pam_delete(msgbuf);
 	_pam_drop(pam_resp);
-	free(msgbuf);
 	if (retval != PAM_SUCCESS)
 		pam_syslog(pamh, LOG_ERR, "Conversation failure: %s",
 			   pam_strerror(pamh, retval));

--- a/pam_tcb/pam_unix_passwd.c
+++ b/pam_tcb/pam_unix_passwd.c
@@ -547,11 +547,11 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 		retval = unix_approve_pass(pamh, oldpass, newpass);
 	}
 
-	_pam_overwrite((char *)oldpass);
+	pam_tcb_overwrite_string((char *)oldpass);
 
 	if (retval != PAM_SUCCESS) {
 		pam_syslog(pamh, LOG_NOTICE, "New password not acceptable");
-		_pam_overwrite((char *)newpass);
+		pam_tcb_overwrite_string((char *)newpass);
 		return retval;
 	}
 
@@ -562,7 +562,7 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags,
 
 	/* First we hash the new password and forget the plaintext. */
 	newhash = do_crypt(pamh, newpass);
-	_pam_overwrite((char *)newpass);
+	pam_tcb_overwrite_string((char *)newpass);
 
 	D(("password processed"));
 

--- a/pam_tcb/support.h
+++ b/pam_tcb/support.h
@@ -147,10 +147,19 @@ struct unix_verify_password_param {
 	const char *pass;
 };
 
+#define pam_tcb_overwrite_string(xx)					\
+{									\
+	void *xx__ = xx;						\
+	if (xx__) {							\
+		xx__ = memset(xx__, '\0', strlen(xx__));		\
+		__asm__ __volatile__ ("" : : "r"(xx__) : "memory");	\
+	}								\
+}
+
 /* use this to free strings, ESPECIALLY password strings */
 #define _pam_delete(xx) \
 { \
-	_pam_overwrite(xx); \
+	pam_tcb_overwrite_string(xx); \
 	_pam_drop(xx); \
 }
 


### PR DESCRIPTION
The use of deprecated _pam_overwrite macro breaks build of these new CI jobs, so fix it as well.