### PR TITLE
Makefile: Pass CFLAGS to the compiler when invoking the linker.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2024-12-12  Björn Esser  <besser82 at fedoraproject.org>
+
+	Makefile: Pass CFLAGS to the compiler when invoking the linker.
+	Some CFLAGS imply effects on the linker too (e.g., -fsanitize=),
+	so they must get passed within the linker rule as well.
+	* libs/Makefile: Pass CFLAGS to the compiler when linking.
+	* pam_tcb/Makefile: Likewise.
+	* progs/Makefile: Likewise.
+	* LICENSE: Update copyright for this contribution.
+
 2024-10-17  Dmitry V. Levin  <ldv at owl.openwall.com>
 
 	pam_tcb: Do not use deprecated _pam_overwrite macro.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2001, 2002 Rafal Wojtczuk <nergal at owl.openwall.com>
 Copyright (c) 2001 - 2003 Solar Designer <solar at owl.openwall.com>
 Copyright (c) 2001, 2003 - 2006, 2009, 2010, 2012, 2018, 2020 Dmitry V. Levin <ldv at owl.openwall.com>
-Copyright (c) 2021 Björn Esser <besser82 at fedoraproject.org>
+Copyright (c) 2021, 2024 Björn Esser <besser82 at fedoraproject.org>
 
 Additionally, some or all of the following copyright notices may apply
 to portions of pam_tcb and tcb_chkpwd:

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -17,13 +17,13 @@ libtcb_a.o: libtcb.c
 	$(CC) $(CFLAGS) $(DBGFLAG) -c $< -o $@
 
 $(LIBTCB_LONG): libtcb.o $(LIB_MAP)
-	$(CC) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBTCB) \
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBTCB) \
 		-Wl,--version-script=$(LIB_MAP) $<
 	ln -sf $@ $(LIBTCB)
 	ln -sf $(LIBTCB) libtcb.so
 
 $(LIBNSS): nss.o $(NSS_MAP) $(LIBTCB_LONG)
-	$(CC) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBNSS) \
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ -Wl,-soname,$(LIBNSS) \
 		-Wl,--version-script=$(NSS_MAP) $< -ltcb
 
 .c.o:

--- a/pam_tcb/Makefile
+++ b/pam_tcb/Makefile
@@ -17,7 +17,7 @@ LIBOBJ = $(LIBSRC:.c=.o)
 all: $(PAM_TCB)
 
 $(PAM_TCB): $(LIBOBJ) $(PAM_MAP)
-	$(CC) $(LDFLAGS) -shared -o $@ $(PAM_TCB_SONAME) \
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $(PAM_TCB_SONAME) \
 		-Wl,--version-script=$(PAM_MAP) $(LIBOBJ) -lcrypt -lpam -ltcb
 
 .c.o:

--- a/progs/Makefile
+++ b/progs/Makefile
@@ -7,13 +7,13 @@ CHKPWD = tcb_chkpwd
 all: $(CONVERT) $(UNCONVERT) $(CHKPWD)
 
 $(CONVERT): $(CONVERT).o
-	$(CC) $(LDFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 $(UNCONVERT): $(UNCONVERT).o
-	$(CC) $(LDFLAGS) -o $@ $< -ltcb
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -ltcb
 
 $(CHKPWD): $(CHKPWD).o
-	$(CC) $(LDFLAGS) -o $@ $< -lcrypt
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< -lcrypt
 
 .c.o:
 	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
Some CFLAGS imply effects on the linker too (e.g., -fsanitize=), so they must get passed within the linker rule as well.