### PR TITLE
make: Add an option to omit the PAM module during build and install.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,13 @@
 	applications to be TCB aware easier.
 	* libs/libtcb.map: Declare version for exported symbols.
 
+	Add an option to omit the PAM module during build and install.
+	This may be needed in distribution packages when preparing a
+	bootstrap environment for new architectures.
+	* Make.defs: Add OMIT_PAM_MODULE flag.
+	* Makefile: Do not build/install the pam module if the
+	OMIT_PAM_MODULE flag is set.
+
 	* pam_tcb/Makefile: Move PAM_SO_SUFFIX to Make.defs.
 	* Make.defs: Likewise.
 

--- a/Make.defs
+++ b/Make.defs
@@ -5,6 +5,10 @@ MKDIR = mkdir
 # Flag to enable -Werror on build.
 WERROR =
 
+# Option to omit the PAM module during build and installation.
+# May be needed when bootstrapping new architectures.
+OMIT_PAM_MODULE =
+
 # Option to configure the suffix appended to pam_tcb.so.
 # May be needed when compiling to use with OpenPAM.
 PAM_SO_SUFFIX =

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+include ./Make.defs
+
 all install install-non-root clean:
 	$(MAKE) -C misc $@
 	$(MAKE) -C libs $@
 	$(MAKE) -C progs $@
+ifeq ($(OMIT_PAM_MODULE),)
 	$(MAKE) -C pam_tcb $@
+endif
 
 install-pam_unix install-pam_pwdb:
 	$(MAKE) -C pam_tcb $@


### PR DESCRIPTION
This may be needed in distribution packages when preparing a bootstrap environment for new architectures.