### PR TITLE
libnss_tcb: Initialize or rewind dirstream from inside setspent(3).

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,17 @@
-2021-12-18  Björn Esser  <besser82 at fedoraproject.org>
+2024-12-18  Björn Esser  <besser82 at fedoraproject.org>
+
+	libnss_tcb: Initialize or rewind dirstream from inside setspent(3).
+	On first call to setspent(3) initialize the directory stream properly;
+	on subsequent calls use rewinddir(3) to reset the position of the
+	directory stream to the beginning of the directory, and also update
+	the existing directory stream to refer to the current state of the
+	underlying directory it operates on.  As all internal functions are
+	operating on thread-local storage now, this operation will be safe,
+	since it will emit no effects outside of the thread calling the
+	setspent(3) function itself.
+	* libs/nss.c (_nss_tcb_setspent): Initialize or rewind dirstream.
+	(_nss_tcb_getspent_r): Move initialization of the dirstream to
+	_nss_tcb_setspent.
 
 	libtcb: Add versioning to exported symbols.
 	This change is implemented for adding some interfaces to libtcb to

--- a/libs/nss.c
+++ b/libs/nss.c
@@ -15,6 +15,15 @@ static __thread DIR *tcbdir = NULL;
 
 int _nss_tcb_setspent(void)
 {
+	if (!tcbdir) {
+		tcbdir = opendir(TCB_DIR);
+		if (!tcbdir)
+			return NSS_STATUS_UNAVAIL;
+
+		return 1;
+	}
+
+	rewinddir(tcbdir);
 	return 1;
 }
 
@@ -101,9 +110,8 @@ int _nss_tcb_getspent_r(struct spwd *__result_buf,
 	int retval, saved_errno;
 
 	if (!tcbdir) {
-		tcbdir = opendir(TCB_DIR);
-		if (!tcbdir)
-			return NSS_STATUS_UNAVAIL;
+		errno = ENOENT;
+		return NSS_STATUS_UNAVAIL;
 	}
 
 	do {


### PR DESCRIPTION
On first call to setspent(3) initialize the directory stream properly;  on subsequent calls use rewinddir(3) to reset the position of the directory stream to the beginning of the directory, and also update the existing directory stream to refer to the current state of the underlying directory it operates on.  As all internal functions are operating on thread-local storage now, this operation will be safe, since it will emit no effects outside of the thread calling the setspent(3) function itself.