### PR TITLE
tcb_(un)convert: Check for UID and EUID to be 0 before proceeding.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2024-12-22  Björn Esser  <besser82 at fedoraproject.org>
+
+	tcb_(un)convert: Check for UID and EUID to be 0 before proceeding.
+	Ensuring the program is run with root privileges on startup is the
+	safer approach instead on relying that mode 0700 may prevent the
+	tool being run by a regular system user.
+	* progs/tcb_convert.c (main): Check for UID and EUID to be 0 before
+	proceeding.
+	* progs/tcb_unconvert.c (main): Likewise.
+
 2024-12-20  Björn Esser  <besser82 at fedoraproject.org>
 
 	libnss_tcb: Disallow potentially-malicious user names in getspnam(3).

--- a/progs/tcb_convert.c
+++ b/progs/tcb_convert.c
@@ -265,6 +265,11 @@ int main(void)
 {
 	int status;
 
+	if (getuid() || geteuid()) {
+		fprintf(stderr, "Only root can do this!\n");
+		return 1;
+	}
+
 	if (lckpwdf()) {
 		perror("lckpwdf");
 		return 1;

--- a/progs/tcb_unconvert.c
+++ b/progs/tcb_unconvert.c
@@ -222,6 +222,11 @@ int main(void)
 	gid_t sysgid;
 	int status;
 
+	if (getuid() || geteuid()) {
+		fprintf(stderr, "Only root can do this!\n");
+		return 1;
+	}
+
 	gr = getgrnam("sys");
 	if (!gr) {
 		fprintf(stderr, "\"sys\" group not found.\n");


### PR DESCRIPTION
Ensuring the program is run with root privileges on startup is the safer approach instead on relying that mode 0700 may prevent the tool being run by a regular system user.