### PR TITLE
Makefile: Apply minimum hardening to libs and applications.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,17 @@
 	proceeding.
 	* progs/tcb_unconvert.c (main): Likewise.
 
+	Makefile: Apply minimum hardening to libs and applications.
+	This enables stack-protector-strong with _FORTIFY_SOURCE=2, and the
+	following linker flags:
+	-Wl,-z,defs: Disallows undefined symbols at link-time.
+	-Wl,-z,relro: Relocation Read-Only protects the Global Offset Table
+		      (GOT) in ELF binaries from being overwritten.
+	-Wl,-z,now: Tell the dynamic linker to resolve all symbols when the
+		    program is started, or when the shared library is loaded.
+	* Make.defs: Define HARDENING_(C|LD)FLAGS, and prepend to coresponding
+	CFLAGS or LDFLAGS variable.
+
 2024-12-20  Björn Esser  <besser82 at fedoraproject.org>
 
 	libnss_tcb: Disallow potentially-malicious user names in getspnam(3).

--- a/Make.defs
+++ b/Make.defs
@@ -13,6 +13,10 @@ OMIT_PAM_MODULE =
 # May be needed when compiling to use with OpenPAM.
 PAM_SO_SUFFIX =
 
+# Flags for hardening.
+HARDENING_CFLAGS  = -fstack-protector-strong -D_FORTIFY_SOURCE=2
+HARDENING_LDFLAGS = -Wl,-z,defs -Wl,-z,relro -Wl,-z,now
+
 DBGFLAG = #-ggdb
 ifndef CFLAGS
 CFLAGS = -O2
@@ -23,7 +27,8 @@ ifneq ($(WERROR),)
 CFLAGS += -Werror
 endif
 #CFLAGS += -DFAIL_RECORD
-LDFLAGS += $(DBGFLAG) -L../libs
+CFLAGS  := $(HARDENING_CFLAGS) $(CFLAGS)
+LDFLAGS := $(HARDENING_LDFLAGS) $(LDFLAGS) $(DBGFLAG) -L../libs
 
 PREFIX = /usr
 SBINDIR = /sbin


### PR DESCRIPTION
* -Wl,-z,defs: Disallows undefined symbols at link-time.
* -Wl,-z,relro: Relocation Read-Only protects the Global Offset Table (GOT) in ELF binaries from being overwritten.
* -Wl,-z,now: Tell the dynamic linker to resolve all symbols when the program is started, or when the shared library is loaded.